### PR TITLE
Fix MG crash when computing PDF weights

### DIFF
--- a/HTT_MG5_aMC_v2_5_1_TEMPLATE/Cards/run_card.dat
+++ b/HTT_MG5_aMC_v2_5_1_TEMPLATE/Cards/run_card.dat
@@ -276,6 +276,6 @@
 None = sys_alpsfact  # \alpha_s emission scale factors
 auto = sys_matchscale # variation of merging scale
 # PDF sets and number of members (0 or none for all members).
-NNPDF30_lo_as_0130 && CT14lo && MMHT2014lo68cl && MMHT2014lo_asmzsmallrange = sys_pdf # separate by && if more than one set.
+NNPDF30_lo_as_0130 && MMHT2014lo68cl && MMHT2014lo_asmzsmallrange 3 && CT14lo 1 = sys_pdf # separate by && if more than one set.
 # MSTW2008nlo68cl.LHgrid 1  = sys_pdf
 #


### PR DESCRIPTION
Apparently, by default MadGraph uses methods to access PDF uncertainties, but there are no *uncertainties* in MMHT2014lo_asmzsmallrange and CT14lo. The change means: take first 3
PDFs from the MMHT set and the first PDF from the CT14 set; these are the total numbers of available PDFs, of course.